### PR TITLE
Added Deezer, PodCloud and Majelan.

### DIFF
--- a/src/user-agents.json
+++ b/src/user-agents.json
@@ -802,5 +802,23 @@
             "^Subcast"
         ],
         "app": "Subcast"
+    },
+    {
+        "user_agents": [
+            "^MajelanApp"
+        ],
+        "app": "Majelan"
+    },
+    {
+        "user_agents": [
+            "^Deezer"
+        ],
+        "app": "Deezer"
+    },
+    {
+        "user_agents": [
+            "podCloud"
+        ],
+        "app": "PodCloud"
     }
 ]


### PR DESCRIPTION
I added 3 user-agents I found in my log files over the last 3 days:

**Deezer** (1793 hits):

```
Deezer/4.13.4 (Electron; osx/10.13.6; Desktop; fr)
Deezer/6.1.3.58 (Android; 9; Mobile; fr) samsung SM-G950F
Deezer/6.1.4.136 (Android; 8.0.0; Mobile; fr) Sony G3121
Deezer/6.1.5.104 (Android; 8.0.0; Mobile; fr) HUAWEI WAS-LX1A
Deezer/6.1.6.62 (Android; 7.0; Mobile; us) samsung SM-A310F
Deezer/6.1.6.62 (Android; 9; Mobile; fr) samsung SM-G960F
Deezer/6.1.6.62 (Android; 9; Mobile; fr) samsung SM-G970F
Deezer/6.1.7.101 (Android; 6.0.1; Tablet; fr) Sony SGP611
Deezer/6.1.7.101 (Android; 8.0.0; Mobile; fr) Sony F8331
Deezer/6.1.7.101 (Android; 8.0.0; Mobile; fr) TCL 5099D
Deezer/6.1.7.101 (Android; 9; Mobile; fr) samsung SM-G970F
Deezer/6.1.7.111 (Android; 5.1.1; Mobile; fr) samsung SM-J320FN
Deezer/6.1.7.111 (Android; 6.0.1; Mobile; fr) samsung SM-A300FU
Deezer/6.1.7.111 (Android; 6.0.1; Mobile; fr) samsung SM-N910F
Deezer/6.1.7.111 (Android; 7.0; Mobile; fr) Sony F3211
Deezer/6.1.7.111 (Android; 7.0; Tablet; fr) Acer A3-A50
Deezer/6.1.7.111 (Android; 7.0; Tablet; it) HUAWEI AGS-W09
Deezer/6.1.7.111 (Android; 7.1.2; Mobile; fr) WIKO View Prime
Deezer/6.1.7.111 (Android; 8.0.0; Mobile; fr) HUAWEI WAS-LX1A
Deezer/6.1.7.111 (Android; 8.0.0; Mobile; fr) samsung SM-G930F
Deezer/6.1.7.111 (Android; 8.0.0; Mobile; fr) samsung SM-G950F
Deezer/6.1.7.111 (Android; 8.0.0; Mobile; fr) Sony G3112
Deezer/6.1.7.111 (Android; 8.1.0; Mobile; fr) samsung SM-G615F
Deezer/6.1.7.111 (Android; 8.1.0; Mobile; fr) WIKO W_P200
Deezer/6.1.7.111 (Android; 8.1.0; Tablet; fr) samsung SM-T580
Deezer/6.1.7.111 (Android; 9; Mobile; fr) OnePlus ONEPLUS A3000
Deezer/6.1.7.111 (Android; 9; Mobile; fr) samsung SM-A405FN
Deezer/6.1.7.111 (Android; 9; Mobile; fr) samsung SM-A600FN
Deezer/6.1.7.111 (Android; 9; Mobile; fr) samsung SM-G960F
Deezer/6.1.7.111 (Android; 9; Mobile; fr) samsung SM-G970F
Deezer/6.1.7.111 (Android; 9; Mobile; fr) samsung SM-J600FN
Deezer/6.1.7.111 (Android; 9; Mobile; fr) samsung SM-N960F
Deezer/6.1.7.111 (Android; 9; Mobile; fr) Xiaomi Redmi Note 6 Pro
Deezer/6.1.8.54 (Android; 7.0; Mobile; fr) HUAWEI BLN-L21
Deezer/6.1.8.54 (Android; 8.0.0; Mobile; fr) HUAWEI PRA-LX1
Deezer/6.1.8.54 (Android; 8.1.0; Tablet; fr) samsung SM-T580
Deezer/6.1.8.54 (Android; 9; Mobile; fr) samsung SM-G950F
Deezer/6.1.8.54 (Android; 9; Mobile; fr) samsung SM-G965F
Deezer/6.1.8.54 (Android; 9; Mobile; fr) samsung SM-J600FN
Deezer/6.1.8.54 (Android; 9; Mobile; fr) TCL T780H
Deezer/7.14.0.4 CFNetwork/976 Darwin/18.2.0
Deezer/7.14.0.4 CFNetwork/978.0.7 Darwin/18.6.0
Deezer/7.14.0.4 CFNetwork/978.0.7 Darwin/18.7.0
Deezer/7.15.0.4 CFNetwork/811.5.4 Darwin/16.7.0
Deezer/7.15.0.4 CFNetwork/978.0.7 Darwin/18.5.0
Deezer/7.15.0.4 CFNetwork/978.0.7 Darwin/18.6.0
Deezer/7.15.0.4 CFNetwork/978.0.7 Darwin/18.7.0
Deezer/7.16.0.5 CFNetwork/978.0.7 Darwin/18.7.0
Deezer/7.6.1.0 CFNetwork/976 Darwin/18.2.0
Deezer/7.9.1.1 CFNetwork/811.5.4 Darwin/16.7.0
```


**PodCloud** (79 hits):

```
MediaAnalyzer podCloud/3.9.0-f575fbd4 (Podcast app like iTunes/12.0; Reason: media-5d65d059a9b497604ab20706)
MediaAnalyzer podCloud/3.9.0-f575fbd4 (Podcast app like iTunes/12.0; Reason: media-5d65d05da9b497604ab20714)
MediaAnalyzer/podCloud 1.1 (like iTunes/10.0)
```


**Majelan** (4 hits):
```
MajelanApp/115 CFNetwork/978.0.7 Darwin/18.7.0
```